### PR TITLE
NETOBSERV-101 R&D: Kube enricher write path for downstream operator

### DIFF
--- a/loki/client.go
+++ b/loki/client.go
@@ -336,6 +336,11 @@ func (c *Client) send(ctx context.Context, tenantID string, buf []byte) (int, er
 		req.Header.Set("X-Scope-OrgID", tenantID)
 	}
 
+	// Authorization header to send if you are using a gateway like https://github.com/observatorium/api for example
+	if c.cfg.Authorization != "" {
+		req.Header.Set("Authorization", c.cfg.Authorization)
+	}
+
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return -1, err

--- a/loki/config.go
+++ b/loki/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	// single tenant mode)
 	TenantID string `yaml:"tenant_id"`
 
+	// The authorization header to send to Loki gateway
+	Authorization string `yaml:"authorization_header"`
+
 	// Use Loki JSON api as opposed to the snappy protobuf.
 	EncodeJson bool `yaml:"encode_json"`
 }

--- a/loki/config_test.go
+++ b/loki/config_test.go
@@ -22,6 +22,8 @@ url: http://localhost:3100/loki/api/v1/push
 
 var clientCustomConfig = `
 url: http://localhost:3100/loki/api/v1/push
+tenant_id: tenant-id
+authorization_header: Bearer XXX
 backoff_config:
   max_retries: 20
   min_period: 5s
@@ -60,6 +62,8 @@ func Test_Config(t *testing.T) {
 				URL: urlutil.URLValue{
 					URL: u,
 				},
+				TenantID:      "tenant-id",
+				Authorization: "Bearer XXX",
 				BackoffConfig: backoff.BackoffConfig{
 					MaxBackoff: 1 * time.Minute,
 					MaxRetries: 20,


### PR DESCRIPTION
This PR adds Authorization header to loki client

This header can contains [service account token](https://github.com/observatorium/api/blob/218434b4598ecf0710aa5a1bdab5d950398868a2/authentication/openshift.go#L414) to authenticate in [loki operator gateway](https://github.com/observatorium/api)