### PR TITLE
GRPC client implementation

### DIFF
--- a/grpc/batch.go
+++ b/grpc/batch.go
@@ -1,0 +1,109 @@
+package grpc
+
+import (
+	"time"
+
+	"github.com/netobserv/loki-client-go/pkg/logproto"
+	"github.com/prometheus/common/model"
+)
+
+// entry represents a log entry with tenant and label information
+type entry struct {
+	tenantID string
+	labels   model.LabelSet
+	logproto.Entry
+}
+
+// batch holds pending log streams waiting to be sent to Loki via GRPC.
+// Similar to HTTP batch but optimized for GRPC operations.
+type batch struct {
+	streams   map[string]*logproto.Stream
+	bytes     int
+	createdAt time.Time
+	tenantID  string // GRPC batches are per-tenant for connection management
+}
+
+// newBatch creates a new batch for a specific tenant
+func newBatch(tenantID string, entries ...entry) *batch {
+	b := &batch{
+		streams:   map[string]*logproto.Stream{},
+		bytes:     0,
+		createdAt: time.Now(),
+		tenantID:  tenantID,
+	}
+
+	// Add entries to the batch
+	for _, entry := range entries {
+		b.add(entry)
+	}
+
+	return b
+}
+
+// add an entry to the batch
+func (b *batch) add(entry entry) {
+	b.bytes += len(entry.Line)
+
+	// Append the entry to an already existing stream (if any)
+	labels := entry.labels.String()
+	if stream, ok := b.streams[labels]; ok {
+		stream.Entries = append(stream.Entries, entry.Entry)
+		return
+	}
+
+	// Add the entry as a new stream
+	b.streams[labels] = &logproto.Stream{
+		Labels:  labels,
+		Entries: []logproto.Entry{entry.Entry},
+	}
+}
+
+// sizeBytes returns the current batch size in bytes
+func (b *batch) sizeBytes() int {
+	return b.bytes
+}
+
+// sizeBytesAfter returns the size of the batch after the input entry
+// will be added to the batch itself
+func (b *batch) sizeBytesAfter(entry entry) int {
+	return b.bytes + len(entry.Line)
+}
+
+// age of the batch since its creation
+func (b *batch) age() time.Duration {
+	return time.Since(b.createdAt)
+}
+
+// createPushRequest creates a push request from the batch
+func (b *batch) createPushRequest() (*logproto.PushRequest, int) {
+	req := &logproto.PushRequest{
+		Streams: make([]logproto.Stream, 0, len(b.streams)),
+	}
+
+	entriesCount := 0
+	for _, stream := range b.streams {
+		req.Streams = append(req.Streams, *stream)
+		entriesCount += len(stream.Entries)
+	}
+
+	return req, entriesCount
+}
+
+// isEmpty returns true if the batch has no entries
+func (b *batch) isEmpty() bool {
+	return len(b.streams) == 0
+}
+
+// streamCount returns the number of streams in the batch
+func (b *batch) streamCount() int {
+	return len(b.streams)
+}
+
+// entryCount returns the total number of entries across all streams
+func (b *batch) entryCount() int {
+	count := 0
+	for _, stream := range b.streams {
+		count += len(stream.Entries)
+	}
+	return count
+}

--- a/grpc/batch_test.go
+++ b/grpc/batch_test.go
@@ -1,0 +1,198 @@
+package grpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/netobserv/loki-client-go/pkg/logproto"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBatch(t *testing.T) {
+	tenantID := "test-tenant"
+	
+	// Test empty batch
+	b := newBatch(tenantID)
+	assert.Equal(t, tenantID, b.tenantID)
+	assert.Equal(t, 0, b.bytes)
+	assert.True(t, b.isEmpty())
+	assert.Equal(t, 0, b.streamCount())
+	assert.Equal(t, 0, b.entryCount())
+	
+	// Test batch with initial entries
+	entry1 := entry{
+		tenantID: tenantID,
+		labels:   model.LabelSet{"job": "test"},
+		Entry: logproto.Entry{
+			Timestamp: time.Now(),
+			Line:      "test log line 1",
+		},
+	}
+	
+	entry2 := entry{
+		tenantID: tenantID,
+		labels:   model.LabelSet{"job": "test"},
+		Entry: logproto.Entry{
+			Timestamp: time.Now(),
+			Line:      "test log line 2",
+		},
+	}
+	
+	b2 := newBatch(tenantID, entry1, entry2)
+	assert.Equal(t, tenantID, b2.tenantID)
+	assert.Equal(t, len("test log line 1")+len("test log line 2"), b2.bytes)
+	assert.False(t, b2.isEmpty())
+	assert.Equal(t, 1, b2.streamCount()) // Same labels, so same stream
+	assert.Equal(t, 2, b2.entryCount())
+}
+
+func TestBatchAdd(t *testing.T) {
+	tenantID := "test-tenant"
+	b := newBatch(tenantID)
+	
+	entry := entry{
+		tenantID: tenantID,
+		labels:   model.LabelSet{"job": "test", "instance": "localhost"},
+		Entry: logproto.Entry{
+			Timestamp: time.Now(),
+			Line:      "test log line",
+		},
+	}
+	
+	// Add first entry
+	b.add(entry)
+	assert.Equal(t, len("test log line"), b.bytes)
+	assert.Equal(t, 1, b.streamCount())
+	assert.Equal(t, 1, b.entryCount())
+	
+	// Add entry with same labels (should go to same stream)
+	entry2 := entry
+	entry2.Line = "another line"
+	b.add(entry2)
+	assert.Equal(t, len("test log line")+len("another line"), b.bytes)
+	assert.Equal(t, 1, b.streamCount())
+	assert.Equal(t, 2, b.entryCount())
+	
+	// Add entry with different labels (should create new stream)
+	entry3 := entry
+	entry3.labels = model.LabelSet{"job": "different"}
+	entry3.Line = "different stream"
+	b.add(entry3)
+	assert.Equal(t, len("test log line")+len("another line")+len("different stream"), b.bytes)
+	assert.Equal(t, 2, b.streamCount())
+	assert.Equal(t, 3, b.entryCount())
+}
+
+func TestBatchSizeBytes(t *testing.T) {
+	tenantID := "test-tenant"
+	b := newBatch(tenantID)
+	
+	entry := entry{
+		tenantID: tenantID,
+		labels:   model.LabelSet{"job": "test"},
+		Entry: logproto.Entry{
+			Timestamp: time.Now(),
+			Line:      "test",
+		},
+	}
+	
+	assert.Equal(t, 0, b.sizeBytes())
+	
+	expectedSize := len("test")
+	assert.Equal(t, expectedSize, b.sizeBytesAfter(entry))
+	
+	b.add(entry)
+	assert.Equal(t, expectedSize, b.sizeBytes())
+}
+
+func TestBatchAge(t *testing.T) {
+	tenantID := "test-tenant"
+	b := newBatch(tenantID)
+	
+	// Should be very recent
+	age := b.age()
+	assert.True(t, age < 100*time.Millisecond)
+	
+	// Wait a bit and check again
+	time.Sleep(10 * time.Millisecond)
+	age2 := b.age()
+	assert.True(t, age2 > age)
+}
+
+func TestCreatePushRequest(t *testing.T) {
+	tenantID := "test-tenant"
+	timestamp := time.Now()
+	
+	entry1 := entry{
+		tenantID: tenantID,
+		labels:   model.LabelSet{"job": "test1"},
+		Entry: logproto.Entry{
+			Timestamp: timestamp,
+			Line:      "line 1",
+		},
+	}
+	
+	entry2 := entry{
+		tenantID: tenantID,
+		labels:   model.LabelSet{"job": "test1"},
+		Entry: logproto.Entry{
+			Timestamp: timestamp.Add(time.Second),
+			Line:      "line 2",
+		},
+	}
+	
+	entry3 := entry{
+		tenantID: tenantID,
+		labels:   model.LabelSet{"job": "test2"},
+		Entry: logproto.Entry{
+			Timestamp: timestamp.Add(2 * time.Second),
+			Line:      "line 3",
+		},
+	}
+	
+	b := newBatch(tenantID, entry1, entry2, entry3)
+	
+	req, entriesCount := b.createPushRequest()
+	require.NotNil(t, req)
+	assert.Equal(t, 3, entriesCount)
+	assert.Equal(t, 2, len(req.Streams)) // Two different label sets
+	
+	// Check streams
+	streamsByLabel := make(map[string]logproto.Stream)
+	for _, stream := range req.Streams {
+		streamsByLabel[stream.Labels] = stream
+	}
+	
+	// Check first stream (job=test1)
+	stream1, exists := streamsByLabel[`{job="test1"}`]
+	require.True(t, exists)
+	assert.Equal(t, 2, len(stream1.Entries))
+	assert.Equal(t, "line 1", stream1.Entries[0].Line)
+	assert.Equal(t, "line 2", stream1.Entries[1].Line)
+	
+	// Check second stream (job=test2)
+	stream2, exists := streamsByLabel[`{job="test2"}`]
+	require.True(t, exists)
+	assert.Equal(t, 1, len(stream2.Entries))
+	assert.Equal(t, "line 3", stream2.Entries[0].Line)
+}
+
+func TestBatchIsEmpty(t *testing.T) {
+	tenantID := "test-tenant"
+	b := newBatch(tenantID)
+	assert.True(t, b.isEmpty())
+	
+	entry := entry{
+		tenantID: tenantID,
+		labels:   model.LabelSet{"job": "test"},
+		Entry: logproto.Entry{
+			Timestamp: time.Now(),
+			Line:      "test",
+		},
+	}
+	
+	b.add(entry)
+	assert.False(t, b.isEmpty())
+}

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -1,0 +1,340 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/gogo/protobuf/proto"
+	"github.com/netobserv/loki-client-go/pkg/backoff"
+	"github.com/netobserv/loki-client-go/pkg/logproto"
+	"github.com/netobserv/loki-client-go/pkg/metrics"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/version"
+	"github.com/prometheus/prometheus/promql/parser"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	// Label reserved to override the tenant ID while processing pipeline stages
+	ReservedLabelTenantID = "__tenant_id__"
+
+	transportGRPC = "grpc"
+)
+
+var (
+	UserAgent = fmt.Sprintf("loki-grpc-client/%s", version.Version)
+)
+
+func init() {
+	metrics.RegisterMetrics()
+}
+
+// Client for pushing logs via GRPC
+type Client struct {
+	logger  log.Logger
+	cfg     Config
+	conn    *grpc.ClientConn
+	pusher  logproto.PusherClient
+	quit    chan struct{}
+	once    sync.Once
+	entries chan entry
+	wg      sync.WaitGroup
+
+	externalLabels model.LabelSet
+}
+
+// New creates a new GRPC client from config
+func New(cfg Config) (*Client, error) {
+	logger := level.NewFilter(log.NewLogfmtLogger(os.Stdout), level.AllowWarn())
+	return NewWithLogger(cfg, logger)
+}
+
+// NewWithDefault creates a new client with default configuration
+func NewWithDefault(serverAddress string) (*Client, error) {
+	cfg, err := NewDefaultConfig(serverAddress)
+	if err != nil {
+		return nil, err
+	}
+	return New(cfg)
+}
+
+// NewWithLogger creates a new GRPC client with a logger and config
+func NewWithLogger(cfg Config, logger log.Logger) (*Client, error) {
+	if cfg.ServerAddress == "" {
+		return nil, errors.New("grpc client needs server address")
+	}
+
+	c := &Client{
+		logger:         log.With(logger, "component", "grpc-client", "host", cfg.ServerAddress),
+		cfg:            cfg,
+		quit:           make(chan struct{}),
+		entries:        make(chan entry),
+		externalLabels: cfg.ExternalLabels.LabelSet,
+	}
+
+	// Initialize connection
+	if err := c.connect(); err != nil {
+		return nil, fmt.Errorf("failed to connect to GRPC server: %w", err)
+	}
+
+	// Initialize counters to 0
+	for _, counter := range metrics.CountersWithHost {
+		counter.WithLabelValues(c.cfg.ServerAddress, transportGRPC).Add(0)
+	}
+
+	c.wg.Add(1)
+	go c.run()
+	return c, nil
+}
+
+// connect establishes GRPC connection
+func (c *Client) connect() error {
+	opts, err := c.cfg.BuildDialOptions()
+	if err != nil {
+		return err
+	}
+
+	conn, err := grpc.NewClient(c.cfg.ServerAddress, opts...)
+	if err != nil {
+		return err
+	}
+
+	c.conn = conn
+	c.pusher = logproto.NewPusherClient(conn)
+
+	level.Info(c.logger).Log("msg", "connected to GRPC server", "address", c.cfg.ServerAddress)
+	return nil
+}
+
+func (c *Client) run() {
+	batches := map[string]*batch{}
+
+	// Batch timer logic similar to HTTP client
+	minWaitCheckFrequency := 10 * time.Millisecond
+	maxWaitCheckFrequency := c.cfg.BatchWait / 10
+	if maxWaitCheckFrequency < minWaitCheckFrequency {
+		maxWaitCheckFrequency = minWaitCheckFrequency
+	}
+
+	maxWaitCheck := time.NewTicker(maxWaitCheckFrequency)
+
+	defer func() {
+		// Send all pending batches
+		for tenantID, batch := range batches {
+			c.sendBatch(tenantID, batch)
+		}
+		c.wg.Done()
+	}()
+
+	for {
+		select {
+		case <-c.quit:
+			return
+
+		case e := <-c.entries:
+			batch, ok := batches[e.tenantID]
+
+			// Create new batch if doesn't exist
+			if !ok {
+				batches[e.tenantID] = newBatch(e.tenantID, e)
+				break
+			}
+
+			// Send batch if adding entry would exceed max size
+			if batch.sizeBytesAfter(e) > c.cfg.BatchSize {
+				c.sendBatch(e.tenantID, batch)
+				batches[e.tenantID] = newBatch(e.tenantID, e)
+				break
+			}
+
+			// Add entry to existing batch
+			batch.add(e)
+
+		case <-maxWaitCheck.C:
+			// Send batches that have reached max wait time
+			for tenantID, batch := range batches {
+				if batch.age() < c.cfg.BatchWait {
+					continue
+				}
+
+				c.sendBatch(tenantID, batch)
+				delete(batches, tenantID)
+			}
+		}
+	}
+}
+
+func (c *Client) sendBatch(tenantID string, batch *batch) {
+	req, entriesCount := batch.createPushRequest()
+
+	if len(req.Streams) == 0 {
+		return
+	}
+
+	// Calculate wire bytes (protobuf size) to match HTTP client behavior
+	wireBytes := float64(proto.Size(req))
+	metrics.EncodedBytes.WithLabelValues(c.cfg.ServerAddress, transportGRPC).Add(wireBytes)
+
+	backoffCtx := context.Background()
+	backoffInstance := backoff.New(backoffCtx, c.cfg.BackoffConfig)
+	var status string
+	var err error
+
+	for backoffInstance.Ongoing() {
+		start := time.Now()
+		// Create a fresh context for each retry attempt
+		pushCtx := context.Background()
+		err = c.push(pushCtx, tenantID, req)
+
+		// Convert error to status code for metrics
+		status = c.getStatusCode(err)
+		metrics.RequestDuration.WithLabelValues(status, c.cfg.ServerAddress, transportGRPC).Observe(time.Since(start).Seconds())
+
+		if err == nil {
+			// Success metrics
+			metrics.SentEntries.WithLabelValues(c.cfg.ServerAddress, transportGRPC).Add(float64(entriesCount))
+			metrics.SentBytes.WithLabelValues(c.cfg.ServerAddress, transportGRPC).Add(wireBytes)
+
+			c.updateStreamLagMetrics(req.Streams)
+			return
+		}
+
+		level.Warn(c.logger).Log("msg", "error sending batch via GRPC, will retry", "status", status, "error", err)
+		metrics.BatchRetries.WithLabelValues(c.cfg.ServerAddress, transportGRPC).Inc()
+		backoffInstance.Wait()
+	}
+
+	// Failed after all retries
+	if err != nil {
+		level.Error(c.logger).Log("msg", "final error sending batch via GRPC", "status", status, "error", err)
+		metrics.DroppedEntries.WithLabelValues(c.cfg.ServerAddress, transportGRPC).Add(float64(entriesCount))
+		metrics.DroppedBytes.WithLabelValues(c.cfg.ServerAddress, transportGRPC).Add(wireBytes)
+	}
+}
+
+func (c *Client) push(ctx context.Context, tenantID string, req *logproto.PushRequest) error {
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
+	defer cancel()
+
+	// Add tenant ID to metadata if specified
+	if tenantID != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "x-scope-orgid", tenantID)
+	}
+
+	// Add user agent
+	ctx = metadata.AppendToOutgoingContext(ctx, "user-agent", UserAgent)
+
+	// gRPC handles connection management automatically
+	_, err := c.pusher.Push(ctx, req)
+	return err
+}
+
+func (c *Client) getStatusCode(err error) string {
+	if err == nil {
+		return "200"
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		return "Unknown"
+	}
+
+	// Convert gRPC status codes to HTTP-like status codes for metrics compatibility
+	switch st.Code() {
+	case codes.OK:
+		return "200"
+	case codes.ResourceExhausted:
+		return "429" // Rate limited
+	case codes.Internal, codes.Aborted, codes.Unavailable:
+		return "500"
+	case codes.DeadlineExceeded:
+		return "504" // Gateway timeout
+	default:
+		return strconv.Itoa(int(st.Code()))
+	}
+}
+
+func (c *Client) getTenantID(labels model.LabelSet) string {
+	// Check if overridden in pipeline stages
+	if value, ok := labels[ReservedLabelTenantID]; ok {
+		return string(value)
+	}
+
+	// Check config
+	if c.cfg.TenantID != "" {
+		return c.cfg.TenantID
+	}
+
+	return ""
+}
+
+// Stop the client
+func (c *Client) Stop() {
+	c.once.Do(func() {
+		close(c.quit)
+
+		if c.conn != nil {
+			c.conn.Close()
+		}
+	})
+	c.wg.Wait()
+}
+
+// updateStreamLagMetrics updates lag metrics to match HTTP client behavior
+func (c *Client) updateStreamLagMetrics(streams []logproto.Stream) {
+	for _, s := range streams {
+		lbls, err := parser.ParseMetric(s.Labels)
+		if err != nil {
+			// is this possible?
+			level.Warn(c.logger).Log("msg", "error converting stream label string to label.Labels, cannot update lagging metric", "error", err)
+			return
+		}
+		var lblSet model.LabelSet
+		for i := range lbls {
+			if lbls[i].Name == metrics.LatencyLabel {
+				lblSet = model.LabelSet{
+					model.LabelName(metrics.HostLabel):    model.LabelValue(c.cfg.ServerAddress),
+					model.LabelName(metrics.LatencyLabel): model.LabelValue(lbls[i].Value),
+				}
+			}
+		}
+		if lblSet != nil {
+			metrics.StreamLag.With(lblSet).Set(time.Since(s.Entries[len(s.Entries)-1].Timestamp).Seconds())
+		}
+	}
+}
+
+// Handle implements EntryHandler; adds a new line to the next batch; send is async
+func (c *Client) Handle(ls model.LabelSet, t time.Time, s string) error {
+	if len(c.externalLabels) > 0 {
+		ls = c.externalLabels.Merge(ls)
+	}
+
+	// Get tenant ID and remove special label
+	tenantID := c.getTenantID(ls)
+	if _, ok := ls[ReservedLabelTenantID]; ok {
+		ls = ls.Clone()
+		delete(ls, ReservedLabelTenantID)
+	}
+
+	c.entries <- entry{tenantID, ls, logproto.Entry{
+		Timestamp: t,
+		Line:      s,
+	}}
+	return nil
+}
+
+func (c *Client) UnregisterLatencyMetric(labels model.LabelSet) {
+	labels[metrics.HostLabel] = model.LabelValue(c.cfg.ServerAddress)
+	metrics.StreamLag.Delete(labels)
+}

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -1,0 +1,171 @@
+package grpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestClientNewDefaultConfig(t *testing.T) {
+	serverAddr := "localhost:9095"
+
+	cfg, err := NewDefaultConfig(serverAddr)
+	require.NoError(t, err)
+	assert.Equal(t, serverAddr, cfg.ServerAddress)
+}
+
+func TestNewWithInvalidAddress(t *testing.T) {
+	cfg := Config{
+		ServerAddress: "", // Invalid - empty address
+		BatchWait:     DefaultBatchWait,
+		BatchSize:     DefaultBatchSize,
+		Timeout:       DefaultTimeout,
+	}
+
+	logger := log.NewNopLogger()
+	_, err := NewWithLogger(cfg, logger)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "server address")
+}
+
+func TestGetTenantID(t *testing.T) {
+	cfg := Config{
+		ServerAddress: "localhost:9095",
+		TenantID:      "config-tenant",
+		BatchWait:     DefaultBatchWait,
+		BatchSize:     DefaultBatchSize,
+		Timeout:       DefaultTimeout,
+	}
+
+	client := &Client{
+		cfg: cfg,
+	}
+
+	// Test with no tenant override
+	labels := model.LabelSet{"job": "test"}
+	tenantID := client.getTenantID(labels)
+	assert.Equal(t, "config-tenant", tenantID)
+
+	// Test with tenant override in labels
+	labelsWithOverride := model.LabelSet{
+		"job":                 "test",
+		ReservedLabelTenantID: "override-tenant",
+	}
+	tenantID = client.getTenantID(labelsWithOverride)
+	assert.Equal(t, "override-tenant", tenantID)
+
+	// Test with no config tenant and no override
+	client.cfg.TenantID = ""
+	tenantID = client.getTenantID(labels)
+	assert.Equal(t, "", tenantID)
+}
+
+func TestGetStatusCode(t *testing.T) {
+	client := &Client{}
+
+	// Test nil error (success) - now returns HTTP-compatible status codes
+	assert.Equal(t, "200", client.getStatusCode(nil))
+
+	// Test GRPC errors mapped to HTTP-compatible status codes
+	err := status.Error(codes.InvalidArgument, "test error")
+	assert.Equal(t, "3", client.getStatusCode(err)) // InvalidArgument maps to code 3
+
+	// Test specific mapped codes
+	err = status.Error(codes.Unavailable, "service unavailable")
+	assert.Equal(t, "500", client.getStatusCode(err)) // Unavailable maps to 500
+
+	err = status.Error(codes.ResourceExhausted, "rate limited")
+	assert.Equal(t, "429", client.getStatusCode(err)) // ResourceExhausted maps to 429
+
+	err = status.Error(codes.DeadlineExceeded, "timeout")
+	assert.Equal(t, "504", client.getStatusCode(err)) // DeadlineExceeded maps to 504
+
+	err = status.Error(codes.Internal, "internal error")
+	assert.Equal(t, "500", client.getStatusCode(err)) // Internal maps to 500
+
+	// Test non-GRPC error
+	nonGrpcErr := assert.AnError
+	assert.Equal(t, "Unknown", client.getStatusCode(nonGrpcErr))
+}
+
+func TestClientHandle(t *testing.T) {
+	// Create a client without actually connecting (for unit test)
+	cfg := Config{
+		ServerAddress: "localhost:9095",
+		BatchWait:     100 * time.Millisecond,
+		BatchSize:     1024,
+		Timeout:       time.Second,
+	}
+
+	client := &Client{
+		cfg:            cfg,
+		entries:        make(chan entry, 10),
+		quit:           make(chan struct{}),
+		externalLabels: model.LabelSet{"external": "label"},
+	}
+
+	// Test handling an entry
+	labels := model.LabelSet{"job": "test"}
+	timestamp := time.Now()
+	line := "test log line"
+
+	err := client.Handle(labels, timestamp, line)
+	assert.NoError(t, err)
+
+	// Check that entry was added to channel
+	select {
+	case entry := <-client.entries:
+		assert.Equal(t, "", entry.tenantID) // No tenant ID configured
+		expectedLabels := model.LabelSet{"job": "test", "external": "label"}
+		assert.Equal(t, expectedLabels, entry.labels)
+		assert.Equal(t, timestamp, entry.Timestamp)
+		assert.Equal(t, line, entry.Line)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Entry was not received within timeout")
+	}
+}
+
+func TestClientHandleWithTenantOverride(t *testing.T) {
+	cfg := Config{
+		ServerAddress: "localhost:9095",
+		TenantID:      "default-tenant",
+		BatchWait:     100 * time.Millisecond,
+		BatchSize:     1024,
+		Timeout:       time.Second,
+	}
+
+	client := &Client{
+		cfg:     cfg,
+		entries: make(chan entry, 10),
+		quit:    make(chan struct{}),
+	}
+
+	// Test with tenant override
+	labels := model.LabelSet{
+		"job":                 "test",
+		ReservedLabelTenantID: "override-tenant",
+	}
+	timestamp := time.Now()
+	line := "test log line"
+
+	err := client.Handle(labels, timestamp, line)
+	assert.NoError(t, err)
+
+	// Check entry
+	select {
+	case entry := <-client.entries:
+		assert.Equal(t, "override-tenant", entry.tenantID)
+		// The reserved label should be removed from the final labels
+		_, hasReservedLabel := entry.labels[ReservedLabelTenantID]
+		assert.False(t, hasReservedLabel)
+		assert.Equal(t, model.LabelSet{"job": "test"}, entry.labels)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Entry was not received within timeout")
+	}
+}

--- a/grpc/config.go
+++ b/grpc/config.go
@@ -24,8 +24,6 @@ const (
 	DefaultMaxBackoff           = 5 * time.Minute
 	DefaultMaxRetries       int = 10
 	DefaultTimeout              = 10 * time.Second
-	DefaultMaxRecvMsgSize       = 1024 * 1024 * 64 // 64MB
-	DefaultMaxSendMsgSize       = 1024 * 1024 * 16 // 16MB
 	DefaultKeepAlive            = 30 * time.Second
 	DefaultKeepAliveTimeout     = 5 * time.Second
 )
@@ -40,8 +38,6 @@ type Config struct {
 	BatchSize int           `yaml:"batch_size"`
 
 	// Connection configuration
-	MaxRecvMsgSize int           `yaml:"max_recv_msg_size"`
-	MaxSendMsgSize int           `yaml:"max_send_msg_size"`
 	Timeout        time.Duration `yaml:"timeout"`
 
 	// TLS configuration
@@ -105,8 +101,6 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&c.BatchWait, prefix+"grpc.batch-wait", DefaultBatchWait, "Maximum wait period before sending batch.")
 	f.IntVar(&c.BatchSize, prefix+"grpc.batch-size-bytes", DefaultBatchSize, "Maximum batch size to accrue before sending.")
 
-	f.IntVar(&c.MaxRecvMsgSize, prefix+"grpc.max-recv-msg-size", DefaultMaxRecvMsgSize, "Maximum message size the client can receive.")
-	f.IntVar(&c.MaxSendMsgSize, prefix+"grpc.max-send-msg-size", DefaultMaxSendMsgSize, "Maximum message size the client can send.")
 	f.DurationVar(&c.Timeout, prefix+"grpc.timeout", DefaultTimeout, "Maximum time to wait for server to respond to a request")
 
 	f.BoolVar(&c.TLS.Enabled, prefix+"grpc.tls.enabled", false, "Enable TLS")
@@ -131,13 +125,6 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 func (c *Config) BuildDialOptions() ([]grpc.DialOption, error) {
 	var opts []grpc.DialOption
 
-	// Message size limits
-	opts = append(opts,
-		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(c.MaxRecvMsgSize),
-			grpc.MaxCallSendMsgSize(c.MaxSendMsgSize),
-		),
-	)
 
 	// Keep alive settings
 	opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
@@ -202,8 +189,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			BatchSize:        DefaultBatchSize,
 			BatchWait:        DefaultBatchWait,
 			Timeout:          DefaultTimeout,
-			MaxRecvMsgSize:   DefaultMaxRecvMsgSize,
-			MaxSendMsgSize:   DefaultMaxSendMsgSize,
 			KeepAlive:        DefaultKeepAlive,
 			KeepAliveTimeout: DefaultKeepAliveTimeout,
 		}

--- a/grpc/config.go
+++ b/grpc/config.go
@@ -1,0 +1,218 @@
+package grpc
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/netobserv/loki-client-go/pkg/backoff"
+	"github.com/netobserv/loki-client-go/pkg/labelutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
+)
+
+// Default configuration values for GRPC client
+const (
+	DefaultBatchWait            = 1 * time.Second
+	DefaultBatchSize        int = 1024 * 1024
+	DefaultMinBackoff           = 500 * time.Millisecond
+	DefaultMaxBackoff           = 5 * time.Minute
+	DefaultMaxRetries       int = 10
+	DefaultTimeout              = 10 * time.Second
+	DefaultMaxRecvMsgSize       = 1024 * 1024 * 64 // 64MB
+	DefaultMaxSendMsgSize       = 1024 * 1024 * 16 // 16MB
+	DefaultKeepAlive            = 30 * time.Second
+	DefaultKeepAliveTimeout     = 5 * time.Second
+)
+
+// Config describes configuration for a GRPC pusher client.
+type Config struct {
+	// Server address (host:port)
+	ServerAddress string `yaml:"server_address"`
+
+	// Batching configuration
+	BatchWait time.Duration `yaml:"batch_wait"`
+	BatchSize int           `yaml:"batch_size"`
+
+	// Connection configuration
+	MaxRecvMsgSize int           `yaml:"max_recv_msg_size"`
+	MaxSendMsgSize int           `yaml:"max_send_msg_size"`
+	Timeout        time.Duration `yaml:"timeout"`
+
+	// TLS configuration
+	TLS TLSConfig `yaml:"tls"`
+
+	// Keep alive configuration
+	KeepAlive        time.Duration `yaml:"keep_alive"`
+	KeepAliveTimeout time.Duration `yaml:"keep_alive_timeout"`
+
+	// Retry configuration
+	BackoffConfig backoff.BackoffConfig `yaml:"backoff_config"`
+
+	// Labels to add to any time series when communicating with loki
+	ExternalLabels labelutil.LabelSet `yaml:"external_labels,omitempty"`
+
+	// Tenant ID for multi-tenant mode (empty string means single tenant)
+	TenantID string `yaml:"tenant_id"`
+}
+
+// TLSConfig contains TLS configuration for GRPC client
+type TLSConfig struct {
+	// Enable TLS
+	Enabled bool `yaml:"enabled"`
+
+	// Path to certificate file
+	CertFile string `yaml:"cert_file"`
+
+	// Path to key file
+	KeyFile string `yaml:"key_file"`
+
+	// Path to CA file
+	CAFile string `yaml:"ca_file"`
+
+	// Server name for certificate verification
+	ServerName string `yaml:"server_name"`
+
+	// Skip certificate verification (insecure)
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
+}
+
+// NewDefaultConfig creates a default configuration for a given GRPC server address.
+func NewDefaultConfig(serverAddress string) (Config, error) {
+	var cfg Config
+	f := &flag.FlagSet{}
+	cfg.RegisterFlags(f)
+	if err := f.Parse(nil); err != nil {
+		return cfg, err
+	}
+	cfg.ServerAddress = serverAddress
+	return cfg, nil
+}
+
+// RegisterFlags registers configuration flags
+func (c *Config) RegisterFlags(f *flag.FlagSet) {
+	c.RegisterFlagsWithPrefix("", f)
+}
+
+// RegisterFlagsWithPrefix registers flags with a given prefix
+func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.StringVar(&c.ServerAddress, prefix+"grpc.server-address", "", "GRPC server address (host:port)")
+	f.DurationVar(&c.BatchWait, prefix+"grpc.batch-wait", DefaultBatchWait, "Maximum wait period before sending batch.")
+	f.IntVar(&c.BatchSize, prefix+"grpc.batch-size-bytes", DefaultBatchSize, "Maximum batch size to accrue before sending.")
+
+	f.IntVar(&c.MaxRecvMsgSize, prefix+"grpc.max-recv-msg-size", DefaultMaxRecvMsgSize, "Maximum message size the client can receive.")
+	f.IntVar(&c.MaxSendMsgSize, prefix+"grpc.max-send-msg-size", DefaultMaxSendMsgSize, "Maximum message size the client can send.")
+	f.DurationVar(&c.Timeout, prefix+"grpc.timeout", DefaultTimeout, "Maximum time to wait for server to respond to a request")
+
+	f.BoolVar(&c.TLS.Enabled, prefix+"grpc.tls.enabled", false, "Enable TLS")
+	f.StringVar(&c.TLS.CertFile, prefix+"grpc.tls.cert-file", "", "Path to client certificate file")
+	f.StringVar(&c.TLS.KeyFile, prefix+"grpc.tls.key-file", "", "Path to client key file")
+	f.StringVar(&c.TLS.CAFile, prefix+"grpc.tls.ca-file", "", "Path to CA certificate file")
+	f.StringVar(&c.TLS.ServerName, prefix+"grpc.tls.server-name", "", "Server name for certificate verification")
+	f.BoolVar(&c.TLS.InsecureSkipVerify, prefix+"grpc.tls.insecure-skip-verify", false, "Skip certificate verification")
+
+	f.DurationVar(&c.KeepAlive, prefix+"grpc.keep-alive", DefaultKeepAlive, "Keep alive interval")
+	f.DurationVar(&c.KeepAliveTimeout, prefix+"grpc.keep-alive-timeout", DefaultKeepAliveTimeout, "Keep alive timeout")
+
+	f.IntVar(&c.BackoffConfig.MaxRetries, prefix+"grpc.max-retries", DefaultMaxRetries, "Maximum number of retries when sending batches.")
+	f.DurationVar(&c.BackoffConfig.MinBackoff, prefix+"grpc.min-backoff", DefaultMinBackoff, "Initial backoff time between retries.")
+	f.DurationVar(&c.BackoffConfig.MaxBackoff, prefix+"grpc.max-backoff", DefaultMaxBackoff, "Maximum backoff time between retries.")
+
+	f.Var(&c.ExternalLabels, prefix+"grpc.external-labels", "list of external labels to add to each log (e.g: --grpc.external-labels=lb1=v1,lb2=v2)")
+	f.StringVar(&c.TenantID, prefix+"grpc.tenant-id", "", "Tenant ID to use when pushing logs to Loki.")
+}
+
+// BuildDialOptions creates GRPC dial options from the configuration
+func (c *Config) BuildDialOptions() ([]grpc.DialOption, error) {
+	var opts []grpc.DialOption
+
+	// Message size limits
+	opts = append(opts,
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(c.MaxRecvMsgSize),
+			grpc.MaxCallSendMsgSize(c.MaxSendMsgSize),
+		),
+	)
+
+	// Keep alive settings
+	opts = append(opts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		Time:                c.KeepAlive,
+		Timeout:             c.KeepAliveTimeout,
+		PermitWithoutStream: true,
+	}))
+
+	// TLS configuration
+	if c.TLS.Enabled {
+		tlsConfig := &tls.Config{
+			ServerName:         c.TLS.ServerName,
+			InsecureSkipVerify: c.TLS.InsecureSkipVerify,
+		}
+
+		// Load CA certificate if specified
+		if c.TLS.CAFile != "" {
+			caCert, err := os.ReadFile(c.TLS.CAFile)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read CA certificate file %s: %w", c.TLS.CAFile, err)
+			}
+			caCertPool := x509.NewCertPool()
+			if !caCertPool.AppendCertsFromPEM(caCert) {
+				return nil, fmt.Errorf("failed to parse CA certificate from %s", c.TLS.CAFile)
+			}
+			tlsConfig.RootCAs = caCertPool
+		}
+
+		if c.TLS.CertFile != "" && c.TLS.KeyFile != "" {
+			cert, err := tls.LoadX509KeyPair(c.TLS.CertFile, c.TLS.KeyFile)
+			if err != nil {
+				return nil, err
+			}
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		}
+
+		creds := credentials.NewTLS(tlsConfig)
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	return opts, nil
+}
+
+// UnmarshalYAML implements YAML unmarshaler
+func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type raw Config
+	var cfg raw
+
+	if c.ServerAddress != "" {
+		// Use existing values as defaults
+		cfg = raw(*c)
+	} else {
+		// Set sane defaults
+		cfg = raw{
+			BackoffConfig: backoff.BackoffConfig{
+				MaxBackoff: DefaultMaxBackoff,
+				MaxRetries: DefaultMaxRetries,
+				MinBackoff: DefaultMinBackoff,
+			},
+			BatchSize:        DefaultBatchSize,
+			BatchWait:        DefaultBatchWait,
+			Timeout:          DefaultTimeout,
+			MaxRecvMsgSize:   DefaultMaxRecvMsgSize,
+			MaxSendMsgSize:   DefaultMaxSendMsgSize,
+			KeepAlive:        DefaultKeepAlive,
+			KeepAliveTimeout: DefaultKeepAliveTimeout,
+		}
+	}
+
+	if err := unmarshal(&cfg); err != nil {
+		return err
+	}
+
+	*c = Config(cfg)
+	return nil
+}

--- a/grpc/config_test.go
+++ b/grpc/config_test.go
@@ -18,8 +18,6 @@ func TestNewDefaultConfig(t *testing.T) {
 	assert.Equal(t, DefaultBatchWait, cfg.BatchWait)
 	assert.Equal(t, DefaultBatchSize, cfg.BatchSize)
 	assert.Equal(t, DefaultTimeout, cfg.Timeout)
-	assert.Equal(t, DefaultMaxRecvMsgSize, cfg.MaxRecvMsgSize)
-	assert.Equal(t, DefaultMaxSendMsgSize, cfg.MaxSendMsgSize)
 	assert.Equal(t, DefaultKeepAlive, cfg.KeepAlive)
 	assert.Equal(t, DefaultKeepAliveTimeout, cfg.KeepAliveTimeout)
 }
@@ -71,8 +69,6 @@ func TestConfigRegisterFlagsWithPrefix(t *testing.T) {
 
 func TestBuildDialOptions(t *testing.T) {
 	cfg := Config{
-		MaxRecvMsgSize:   1024 * 1024,
-		MaxSendMsgSize:   512 * 1024,
 		KeepAlive:        30 * time.Second,
 		KeepAliveTimeout: 5 * time.Second,
 		TLS: TLSConfig{
@@ -88,8 +84,6 @@ func TestBuildDialOptions(t *testing.T) {
 
 func TestBuildDialOptionsWithTLS(t *testing.T) {
 	cfg := Config{
-		MaxRecvMsgSize:   1024 * 1024,
-		MaxSendMsgSize:   512 * 1024,
 		KeepAlive:        30 * time.Second,
 		KeepAliveTimeout: 5 * time.Second,
 		TLS: TLSConfig{

--- a/grpc/config_test.go
+++ b/grpc/config_test.go
@@ -1,0 +1,114 @@
+package grpc
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDefaultConfig(t *testing.T) {
+	serverAddr := "localhost:9095"
+	cfg, err := NewDefaultConfig(serverAddr)
+	require.NoError(t, err)
+
+	assert.Equal(t, serverAddr, cfg.ServerAddress)
+	assert.Equal(t, DefaultBatchWait, cfg.BatchWait)
+	assert.Equal(t, DefaultBatchSize, cfg.BatchSize)
+	assert.Equal(t, DefaultTimeout, cfg.Timeout)
+	assert.Equal(t, DefaultMaxRecvMsgSize, cfg.MaxRecvMsgSize)
+	assert.Equal(t, DefaultMaxSendMsgSize, cfg.MaxSendMsgSize)
+	assert.Equal(t, DefaultKeepAlive, cfg.KeepAlive)
+	assert.Equal(t, DefaultKeepAliveTimeout, cfg.KeepAliveTimeout)
+}
+
+func TestConfigRegisterFlags(t *testing.T) {
+	var cfg Config
+	f := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.RegisterFlags(f)
+
+	// Test setting flags
+	args := []string{
+		"-grpc.server-address=localhost:9095",
+		"-grpc.batch-wait=5s",
+		"-grpc.batch-size-bytes=2048",
+		"-grpc.timeout=30s",
+		"-grpc.tls.enabled=true",
+		"-grpc.tls.server-name=loki.example.com",
+		"-grpc.tenant-id=test-tenant",
+	}
+
+	err := f.Parse(args)
+	require.NoError(t, err)
+
+	assert.Equal(t, "localhost:9095", cfg.ServerAddress)
+	assert.Equal(t, 5*time.Second, cfg.BatchWait)
+	assert.Equal(t, 2048, cfg.BatchSize)
+	assert.Equal(t, 30*time.Second, cfg.Timeout)
+	assert.True(t, cfg.TLS.Enabled)
+	assert.Equal(t, "loki.example.com", cfg.TLS.ServerName)
+	assert.Equal(t, "test-tenant", cfg.TenantID)
+}
+
+func TestConfigRegisterFlagsWithPrefix(t *testing.T) {
+	var cfg Config
+	f := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.RegisterFlagsWithPrefix("loki.", f)
+
+	args := []string{
+		"-loki.grpc.server-address=localhost:9095",
+		"-loki.grpc.batch-wait=2s",
+	}
+
+	err := f.Parse(args)
+	require.NoError(t, err)
+
+	assert.Equal(t, "localhost:9095", cfg.ServerAddress)
+	assert.Equal(t, 2*time.Second, cfg.BatchWait)
+}
+
+func TestBuildDialOptions(t *testing.T) {
+	cfg := Config{
+		MaxRecvMsgSize:   1024 * 1024,
+		MaxSendMsgSize:   512 * 1024,
+		KeepAlive:        30 * time.Second,
+		KeepAliveTimeout: 5 * time.Second,
+		TLS: TLSConfig{
+			Enabled:            false,
+			InsecureSkipVerify: true,
+		},
+	}
+
+	opts, err := cfg.BuildDialOptions()
+	require.NoError(t, err)
+	assert.NotEmpty(t, opts)
+}
+
+func TestBuildDialOptionsWithTLS(t *testing.T) {
+	cfg := Config{
+		MaxRecvMsgSize:   1024 * 1024,
+		MaxSendMsgSize:   512 * 1024,
+		KeepAlive:        30 * time.Second,
+		KeepAliveTimeout: 5 * time.Second,
+		TLS: TLSConfig{
+			Enabled:            true,
+			ServerName:         "loki.example.com",
+			InsecureSkipVerify: true,
+		},
+	}
+
+	opts, err := cfg.BuildDialOptions()
+	require.NoError(t, err)
+	assert.NotEmpty(t, opts)
+}
+
+func TestConfigUnmarshalYAML(t *testing.T) {
+	var cfg Config
+	err := cfg.UnmarshalYAML(func(v interface{}) error {
+		// This is a simplified test - in real usage, this would be called by yaml.Unmarshal
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/loki/client_test.go
+++ b/loki/client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/netobserv/loki-client-go/pkg/backoff"
 	"github.com/netobserv/loki-client-go/pkg/httputil"
 	"github.com/netobserv/loki-client-go/pkg/labelutil"
+	"github.com/netobserv/loki-client-go/pkg/metrics"
 	"github.com/netobserv/loki-client-go/pkg/urlutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -68,12 +69,12 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 3.0
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__"} 0
+				# HELP netobserv_loki_sent_entries_total Number of log entries sent to the ingester.
+				# TYPE netobserv_loki_sent_entries_total counter
+				netobserv_loki_sent_entries_total{host="__HOST__",transport="http"} 3.0
+				# HELP netobserv_loki_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+				# TYPE netobserv_loki_dropped_entries_total counter
+				netobserv_loki_dropped_entries_total{host="__HOST__",transport="http"} 0
 			`,
 		},
 		"batch log entries together until the batch wait time is reached": {
@@ -94,12 +95,12 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 2.0
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__"} 0
+				# HELP netobserv_loki_sent_entries_total Number of log entries sent to the ingester.
+				# TYPE netobserv_loki_sent_entries_total counter
+				netobserv_loki_sent_entries_total{host="__HOST__",transport="http"} 2.0
+				# HELP netobserv_loki_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+				# TYPE netobserv_loki_dropped_entries_total counter
+				netobserv_loki_dropped_entries_total{host="__HOST__",transport="http"} 0
 			`,
 		},
 		"retry send a batch up to backoff's max retries in case the server responds with a 5xx": {
@@ -123,12 +124,12 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__"} 1.0
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 0
+				# HELP netobserv_loki_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+				# TYPE netobserv_loki_dropped_entries_total counter
+				netobserv_loki_dropped_entries_total{host="__HOST__",transport="http"} 1.0
+				# HELP netobserv_loki_sent_entries_total Number of log entries sent to the ingester.
+				# TYPE netobserv_loki_sent_entries_total counter
+				netobserv_loki_sent_entries_total{host="__HOST__",transport="http"} 0
 			`,
 		},
 		"do not retry send a batch in case the server responds with a 4xx": {
@@ -144,12 +145,12 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__"} 1.0
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 0
+				# HELP netobserv_loki_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+				# TYPE netobserv_loki_dropped_entries_total counter
+				netobserv_loki_dropped_entries_total{host="__HOST__",transport="http"} 1.0
+				# HELP netobserv_loki_sent_entries_total Number of log entries sent to the ingester.
+				# TYPE netobserv_loki_sent_entries_total counter
+				netobserv_loki_sent_entries_total{host="__HOST__",transport="http"} 0
 			`,
 		},
 		"do retry sending a batch in case the server responds with a 429": {
@@ -173,12 +174,12 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__"} 1.0
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 0
+				# HELP netobserv_loki_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+				# TYPE netobserv_loki_dropped_entries_total counter
+				netobserv_loki_dropped_entries_total{host="__HOST__",transport="http"} 1.0
+				# HELP netobserv_loki_sent_entries_total Number of log entries sent to the ingester.
+				# TYPE netobserv_loki_sent_entries_total counter
+				netobserv_loki_sent_entries_total{host="__HOST__",transport="http"} 0
 			`,
 		},
 		"batch log entries together honoring the client tenant ID": {
@@ -195,12 +196,12 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 2.0
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__"} 0
+				# HELP netobserv_loki_sent_entries_total Number of log entries sent to the ingester.
+				# TYPE netobserv_loki_sent_entries_total counter
+				netobserv_loki_sent_entries_total{host="__HOST__",transport="http"} 2.0
+				# HELP netobserv_loki_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+				# TYPE netobserv_loki_dropped_entries_total counter
+				netobserv_loki_dropped_entries_total{host="__HOST__",transport="http"} 0
 			`,
 		},
 		"batch log entries together honoring the tenant ID overridden while processing the pipeline stages": {
@@ -225,12 +226,12 @@ func TestClient_Handle(t *testing.T) {
 				},
 			},
 			expectedMetrics: `
-				# HELP promtail_sent_entries_total Number of log entries sent to the ingester.
-				# TYPE promtail_sent_entries_total counter
-				promtail_sent_entries_total{host="__HOST__"} 4.0
-				# HELP promtail_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
-				# TYPE promtail_dropped_entries_total counter
-				promtail_dropped_entries_total{host="__HOST__"} 0
+				# HELP netobserv_loki_sent_entries_total Number of log entries sent to the ingester.
+				# TYPE netobserv_loki_sent_entries_total counter
+				netobserv_loki_sent_entries_total{host="__HOST__",transport="http"} 4.0
+				# HELP netobserv_loki_dropped_entries_total Number of log entries dropped because failed to be sent to the ingester after all retries.
+				# TYPE netobserv_loki_dropped_entries_total counter
+				netobserv_loki_dropped_entries_total{host="__HOST__",transport="http"} 0
 			`,
 		},
 	}
@@ -238,8 +239,8 @@ func TestClient_Handle(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			// Reset metrics
-			sentEntries.Reset()
-			droppedEntries.Reset()
+			metrics.SentEntries.Reset()
+			metrics.DroppedEntries.Reset()
 
 			// Create a buffer channel where we do enqueue received requests
 			receivedReqsChan := make(chan receivedReq, 10)
@@ -301,7 +302,7 @@ func TestClient_Handle(t *testing.T) {
 			require.ElementsMatch(t, testData.expectedReqs, receivedReqs)
 
 			expectedMetrics := strings.Replace(testData.expectedMetrics, "__HOST__", serverURL.Host, -1)
-			err = testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expectedMetrics), "promtail_sent_entries_total", "promtail_dropped_entries_total")
+			err = testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expectedMetrics), "netobserv_loki_sent_entries_total", "netobserv_loki_dropped_entries_total")
 			assert.NoError(t, err)
 		})
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,94 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/netobserv/loki-client-go/pkg/metric"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	LatencyLabel = "filename"
+	HostLabel    = "host"
+	MetricPrefix = "netobserv"
+)
+
+var (
+	// Shared metrics for both HTTP and gRPC clients
+	EncodedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricPrefix,
+		Name:      "loki_encoded_bytes_total",
+		Help:      "Number of bytes encoded and ready to send.",
+	}, []string{HostLabel, "transport"})
+
+	SentBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricPrefix,
+		Name:      "loki_sent_bytes_total",
+		Help:      "Number of bytes sent.",
+	}, []string{HostLabel, "transport"})
+
+	DroppedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricPrefix,
+		Name:      "loki_dropped_bytes_total",
+		Help:      "Number of bytes dropped because failed to be sent to the ingester after all retries.",
+	}, []string{HostLabel, "transport"})
+
+	SentEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricPrefix,
+		Name:      "loki_sent_entries_total",
+		Help:      "Number of log entries sent to the ingester.",
+	}, []string{HostLabel, "transport"})
+
+	DroppedEntries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricPrefix,
+		Name:      "loki_dropped_entries_total",
+		Help:      "Number of log entries dropped because failed to be sent to the ingester after all retries.",
+	}, []string{HostLabel, "transport"})
+
+	RequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: MetricPrefix,
+		Name:      "loki_request_duration_seconds",
+		Help:      "Duration of send requests.",
+	}, []string{"status_code", HostLabel, "transport"})
+
+	BatchRetries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricPrefix,
+		Name:      "loki_batch_retries_total",
+		Help:      "Number of times batches has had to be retried.",
+	}, []string{HostLabel, "transport"})
+
+
+	StreamLag *metric.Gauges
+
+	// CountersWithHost are the counters that have host as a label
+	CountersWithHost = []*prometheus.CounterVec{
+		EncodedBytes, SentBytes, DroppedBytes, SentEntries, DroppedEntries, BatchRetries,
+	}
+
+	registrationOnce sync.Once
+)
+
+// RegisterMetrics registers all metrics with prometheus
+func RegisterMetrics() {
+	registrationOnce.Do(func() {
+		prometheus.MustRegister(EncodedBytes)
+		prometheus.MustRegister(SentBytes)
+		prometheus.MustRegister(DroppedBytes)
+		prometheus.MustRegister(SentEntries)
+		prometheus.MustRegister(DroppedEntries)
+		prometheus.MustRegister(RequestDuration)
+		prometheus.MustRegister(BatchRetries)
+
+		var err error
+		StreamLag, err = metric.NewGauges(MetricPrefix+"_stream_lag_seconds",
+			"Difference between current time and last batch timestamp for successful sends",
+			metric.GaugeConfig{Action: "set"},
+			int64(1*time.Minute.Seconds()),
+		)
+		if err != nil {
+			panic(err)
+		}
+		prometheus.MustRegister(StreamLag)
+	})
+}


### PR DESCRIPTION
This PR adds the ability to send logs to Loki (distributor) using grpc.

The idea is to not altered existing files as this repo is a fork from another repo, so the implementation was done in the grpc package very similarly to the http one.

